### PR TITLE
Show label for vocabularies

### DIFF
--- a/src/workspaces/components/VocabulariesTable.tsx
+++ b/src/workspaces/components/VocabulariesTable.tsx
@@ -29,7 +29,7 @@ const DetailPanel = (rowData: Vocabulary) => {
     {
       key: t`changeTrackingVocabulary`,
       value: rowData.changeTrackingVocabulary,
-    }
+    },
   ]
   return (
     <GreyBox pl={6.5}>

--- a/src/workspaces/components/VocabulariesTable.tsx
+++ b/src/workspaces/components/VocabulariesTable.tsx
@@ -10,8 +10,8 @@ import { Box, styled } from '@material-ui/core'
 
 const columns: DataColumn<Vocabulary>[] = [
   {
-    title: t`uri`,
-    field: 'vocabulary',
+    title: t`label`,
+    field: 'label',
   },
   {
     title: t`readOnly`,
@@ -27,17 +27,9 @@ const GreyBox = styled(Box)({
 const DetailPanel = (rowData: Vocabulary) => {
   const data = [
     {
-      key: t`vocabularyContext`,
-      value: rowData.vocabularyContext,
-    },
-    {
-      key: t`changeTrackingContext`,
-      value: rowData.changeTrackingContext,
-    },
-    {
       key: t`changeTrackingVocabulary`,
       value: rowData.changeTrackingVocabulary,
-    },
+    }
   ]
   return (
     <GreyBox pl={6.5}>

--- a/src/workspaces/selectors.ts
+++ b/src/workspaces/selectors.ts
@@ -19,6 +19,7 @@ const convertVocabularyDataToVocabulary = (
   data: VocabularyData
 ): Vocabulary => ({
   uri: data.uri,
+  label: data.label,
   vocabulary: data.basedOnVocabularyVersion,
   isReadOnly: !!data.types && data.types.includes(VOCABULARY_CONTEXT_READ_ONLY),
   vocabularyContext: data.uri,

--- a/src/workspaces/types.ts
+++ b/src/workspaces/types.ts
@@ -5,6 +5,7 @@ export type WorkspacesAction = import('workspaces/actions').WorkspacesAction
 
 export type VocabularyData = {
   uri: Uri
+  label?: string
   types: Uri[]
   basedOnVocabularyVersion: Uri
   changeTrackingContext: {
@@ -18,6 +19,7 @@ export type Vocabulary = Omit<
   'types' | 'basedOnVocabularyVersion' | 'changeTrackingContext'
 > & {
   vocabulary: Uri
+  label?: string
   isReadOnly: boolean
   vocabularyContext: Uri
   changeTrackingContext: Uri

--- a/src/workspaces/types.ts
+++ b/src/workspaces/types.ts
@@ -19,7 +19,6 @@ export type Vocabulary = Omit<
   'types' | 'basedOnVocabularyVersion' | 'changeTrackingContext'
 > & {
   vocabulary: Uri
-  label?: string
   isReadOnly: boolean
   vocabularyContext: Uri
   changeTrackingContext: Uri


### PR DESCRIPTION
Moreover, hides unnecessary metadata (such as URI of contexts)

As there will be later validation constraint that all vocabularies must have label, I did not implement "Missing label" functionality.