### PR TITLE
[#60] Replaced Netlify API proxy with direct API calls

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,11 +1,3 @@
-## This rule redirects to an external API
-[[redirects]]
-  from = "/sgov-server/*"
-  to = "https://kbss.felk.cvut.cz/sgov-server/:splat"
-  status = 200
-  force = true # COMMENT: ensure that we always redirect
-  headers = {X-From = "Netlify"}
-
 ## Redirects any unknown URL to index 
 [[redirects]]
   from = "/*"

--- a/package.json
+++ b/package.json
@@ -85,6 +85,5 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
-  },
-  "proxy": "https://kbss.felk.cvut.cz"
+  }
 }

--- a/src/app/config.ts
+++ b/src/app/config.ts
@@ -1,4 +1,4 @@
 /**
  * API URL base
  */
-export const API_URL = process.env.REACT_APP_API_URL || '/sgov-server'
+export const API_URL = process.env.REACT_APP_API_URL || 'https://kbss.felk.cvut.cz/sgov-server'

--- a/src/app/config.ts
+++ b/src/app/config.ts
@@ -1,4 +1,5 @@
 /**
  * API URL base
  */
-export const API_URL = process.env.REACT_APP_API_URL || 'https://kbss.felk.cvut.cz/sgov-server'
+export const API_URL =
+  process.env.REACT_APP_API_URL || 'https://kbss.felk.cvut.cz/sgov-server'


### PR DESCRIPTION
I removed Netlify API proxy so that the SGOV server is called directly, mostly because of timeout issues when publishing vocabularies. Netlify enforces hard timeout of 28 seconds, beyond this timeout all requests fail as 500.

For the app to work properly, appropriate CORS policy must be set on the SGOV server, particularly to allow requests from:
- localhost:3000
- *.netlify.app

Although the primary domain (for now is) `mission-control.netlify.app`, in order to support PR instances other Netlify subdomains must be allowed as well as the PR instances have randomized names.