### PR TITLE
[#64] Refactored vocabulary URI to IRI

### DIFF
--- a/src/workspaces/api.ts
+++ b/src/workspaces/api.ts
@@ -32,13 +32,13 @@ export const getWorkspaceVocabulariesUrl = (workspaceId: Id) =>
  */
 export const getAddVocabularyUrl = (
   workspaceId: Id,
-  vocabularyUri: Uri,
+  vocabularyIri: Uri,
   readOnly: boolean,
   label?: string
 ) =>
   `${getWorkspaceVocabulariesUrl(
     workspaceId
-  )}?vocabularyUri=${vocabularyUri}&readOnly=${String(readOnly)}&label=${label}`
+  )}?vocabularyUri=${vocabularyIri}&readOnly=${String(readOnly)}&label=${label}`
 
 /**
  * Endpoint to delete vocabulary from a workspace

--- a/src/workspaces/components/AddVocabularyForm.tsx
+++ b/src/workspaces/components/AddVocabularyForm.tsx
@@ -75,7 +75,7 @@ const ImportVocabulary: React.FC<ImportVocabulary> = ({ setTabIndex }) => {
       dispatch(
         Actions.Workspaces.addVocabulary.request({
           workspaceId: workspace!.id,
-          vocabularyUri: selectedVocabulary!.basedOnVocabularyVersion,
+          vocabularyIri: selectedVocabulary!.basedOnVocabularyVersion,
           label: selectedVocabulary!.label,
           readOnly,
         })
@@ -191,7 +191,7 @@ const CreateVocabulary: React.FC = () => {
       (v) => v.label === selectedTypeLabel
     )
     setVocabularyType(selectedTypeLabel)
-    reset({ vocabularyUri: selectedType?.prefix })
+    reset({ vocabularyIri: selectedType?.prefix })
   }
 
   return (
@@ -225,8 +225,8 @@ const CreateVocabulary: React.FC = () => {
         <input type="hidden" name="readOnly" value="false" ref={register} />
         <TextField
           autoComplete="off"
-          name="vocabularyUri"
-          label={t`vocabularyUri`}
+          name="vocabularyIri"
+          label={t`vocabularyIri`}
           defaultValue={vocabularyType?.prefix}
           inputRef={register({
             pattern: {
@@ -234,8 +234,8 @@ const CreateVocabulary: React.FC = () => {
               message: vocabularyType?.regex!,
             },
           })}
-          error={!!errors.vocabularyUri}
-          helperText={errors.vocabularyUri?.message}
+          error={!!errors.vocabularyIri}
+          helperText={errors.vocabularyIri?.message}
         />
         <TextField
           name="label"

--- a/src/workspaces/epics.ts
+++ b/src/workspaces/epics.ts
@@ -98,7 +98,7 @@ const actionsAfterAddWorkspace: Epic = ($action) =>
           }),
           Actions.Workspaces.addVocabulary.request({
             workspaceId: payload,
-            vocabularyUri: DEFAULT_VOCABULARY_IRI,
+            vocabularyIri: DEFAULT_VOCABULARY_IRI,
             readOnly: true,
           })
         )
@@ -202,7 +202,7 @@ const addVocabulary: Epic = ($action) =>
       post(
         getAddVocabularyUrl(
           payload.workspaceId,
-          payload.vocabularyUri,
+          payload.vocabularyIri,
           payload.readOnly,
           payload.label
         )

--- a/src/workspaces/translations/cs.json
+++ b/src/workspaces/translations/cs.json
@@ -28,7 +28,7 @@
   "false": "Ne",
   "addVocabulary": "Přidat slovník",
   "vocabularyType": "Typ slovníku",
-  "vocabularyUri": "URI slovníku",
+  "vocabularyIri": "IRI slovníku",
   "vocabularyLabel": "Název slovníku",
   "addVocabularySuccess": "Slovník přídán do pracovního prostoru",
   "addVocabularyError": "Nepodařilo se přidat slovník do pracovního prostoru",

--- a/src/workspaces/translations/en.json
+++ b/src/workspaces/translations/en.json
@@ -28,7 +28,7 @@
   "false": "No",
   "addVocabulary": "Add a vocabulary",
   "vocabularyType": "Vocabulary type",
-  "vocabularyUri": "Vocabulary URI",
+  "vocabularyIri": "Vocabulary IRI",
   "vocabularyLabel": "Vocabulary label",
   "addVocabularySuccess": "Vocabulary was added to the workspace",
   "addVocabularyError": "Vocabulary cannot be added to the workspace",

--- a/src/workspaces/types.ts
+++ b/src/workspaces/types.ts
@@ -31,7 +31,7 @@ export type Vocabulary = Omit<
 
 export type AddVocabularyPayload = {
   workspaceId: Id
-  vocabularyUri: Uri
+  vocabularyIri: Uri
   label?: string
   readOnly: boolean
 }


### PR DESCRIPTION
Resolves #64.

The SGOV server still accepts `vocabularyUri` as a parameter in an endpoint, this was not touched. In general SGOV server uses URI everywhere which I think is fine.