### PR TITLE
[#121] Provide better error report to user if something goes wrong

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -10,7 +10,7 @@ import Snackbar from 'components/Snackbar'
 import RouteComponentRenderer from './RouteComponentRenderer'
 import { suspendResource } from 'data/suspend'
 import { ErrorBoundary } from 'react-error-boundary'
-import { Error500 } from './Errors'
+import { ErrorFallback } from './Errors'
 import Router from './Router'
 import Title from './Title'
 
@@ -27,7 +27,7 @@ const App: React.FC = () => (
           <Title />
           <ThemeProvider theme={theme}>
             <CssBaseline />
-            <ErrorBoundary FallbackComponent={Error500}>
+            <ErrorBoundary FallbackComponent={ErrorFallback}>
               <Suspense fallback={'...'}>
                 <SuspendHelper />
                 <RouteComponentRenderer />

--- a/src/components/Errors.tsx
+++ b/src/components/Errors.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { AjaxError } from 'rxjs/ajax'
 import { Box, IconButton, styled, Typography } from '@material-ui/core'
 
 import Icon from 'components/Icon'
@@ -13,26 +14,52 @@ const BackdropGradient = styled(Box)({
   justifyContent: 'center',
 })
 
-type ErrorProps = {
+type ErrorPageProps = {
   code: number
   message: string
 }
 
-const ErrorPage: React.FC<ErrorProps> = ({ code, message }) => (
-  <BackdropGradient color="white">
-    <Box p={2} display="flex" alignItems="center">
-      <IconButton color="inherit">
-        <Icon />
-      </IconButton>
-      <Typography variant="h6">{t`controlPanel`}</Typography>
-    </Box>
-    <Typography variant="h1">{code}</Typography>
-    <Typography variant="h3">{t(message)}</Typography>
-  </BackdropGradient>
-)
+const ErrorPage: React.FC<ErrorPageProps> = ({ code, message, children }) => {
+  return (
+    <BackdropGradient color="white">
+      <Box p={2} display="flex" alignItems="center">
+        <IconButton color="inherit">
+          <Icon />
+        </IconButton>
+        <Typography variant="h6">{t`controlPanel`}</Typography>
+      </Box>
+      <Typography variant="h1">{code}</Typography>
+      <Typography variant="h3">{t(message)}</Typography>
+      {children && (
+        <Box maxWidth={500} margin={4}>
+          {children}
+        </Box>
+      )}
+    </BackdropGradient>
+  )
+}
 
 export const Error404 = () => <ErrorPage code={404} message={'pageNotFound'} />
 
-export const Error500 = () => (
-  <ErrorPage code={500} message={'somethingWentWrong'} />
-)
+type ErrorFallbackProps = {
+  error: Error | AjaxError
+}
+
+export const ErrorFallback: React.FC<ErrorFallbackProps> = ({ error }) => {
+  const isAjax = error instanceof AjaxError
+  if (!isAjax) {
+    return <ErrorPage code={500} message={'somethingWentWrong'} />
+  }
+  const ajaxError = error as AjaxError
+  const responseJson = ajaxError.xhr.response
+  return (
+    <ErrorPage code={ajaxError.status} message={'somethingWentWrongWithApi'}>
+      <Typography paragraph style={{ fontFamily: 'monospace' }}>
+        {ajaxError.request.method} {ajaxError.request.url}
+      </Typography>
+      <Typography style={{ fontFamily: 'monospace' }}>
+        {responseJson.message}
+      </Typography>
+    </ErrorPage>
+  )
+}

--- a/src/components/MainLayout.tsx
+++ b/src/components/MainLayout.tsx
@@ -6,14 +6,14 @@ import Footer from './Footer'
 import BackdropGrey from './BackdropGrey'
 import RouteComponentRenderer from './RouteComponentRenderer'
 import { ErrorBoundary } from 'react-error-boundary'
-import { Error500 } from './Errors'
+import { ErrorFallback } from './Errors'
 
 const MainLayout: React.FC = () => {
   return (
     <BackdropGrey>
       <Header />
       <Box display="flex" flexGrow="1" flexDirection="column">
-        <ErrorBoundary FallbackComponent={Error500}>
+        <ErrorBoundary FallbackComponent={ErrorFallback}>
           <Suspense fallback={<></>}>
             <RouteComponentRenderer />
           </Suspense>

--- a/src/i18n/common.cs.json
+++ b/src/i18n/common.cs.json
@@ -4,7 +4,7 @@
   "en": "English",
   "pageNotFound": "Stránka nenalezena",
   "somethingWentWrong": "Něco se pokazilo",
-  "somethingWentWrongWithApi": "Něco se pokazilo s API",
+  "somethingWentWrongWithApi": "Něco se pokazilo při komunikaci se serverem",
   "notAuthorized": "Nedostatečné oprávnění",
   "username": "Uživatelské jméno",
   "password": "Heslo",

--- a/src/i18n/common.cs.json
+++ b/src/i18n/common.cs.json
@@ -4,6 +4,7 @@
   "en": "English",
   "pageNotFound": "Stránka nenalezena",
   "somethingWentWrong": "Něco se pokazilo",
+  "somethingWentWrongWithApi": "Něco se pokazilo s API",
   "notAuthorized": "Nedostatečné oprávnění",
   "username": "Uživatelské jméno",
   "password": "Heslo",

--- a/src/i18n/common.en.json
+++ b/src/i18n/common.en.json
@@ -4,6 +4,7 @@
   "en": "English",
   "pageNotFound": "Page not found",
   "somethingWentWrong": "Something went wrong",
+  "somethingWentWrongWithApi": "Something went wrong with API",
   "notAuthorized": "Not authorized",
   "username": "Username",
   "password": "Password",


### PR DESCRIPTION
The goal of this PR is to give the user better error report if something goes wrong.

If an error origins from a XHR request, then it looks like this (the server message is displayed):
![image](https://user-images.githubusercontent.com/141302/107150110-796c9900-695c-11eb-878e-2b6b434a8ec8.png)

In-app errors are reported as 500 - stack trace or other details are usually meaningless for user, and if someone is interested she can see the full error in console anyway.

Resolves #121 