### PR TITLE
[#120] Fixed issue tracker button wrapping

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -25,19 +25,13 @@ const Header: React.FC = () => {
   return (
     <AppBar position="static" className={classes.root}>
       <Toolbar>
-        <Box display="flex" flexGrow="1" flexBasis="20%" alignItems="center">
+        <Box display="flex" alignItems="center">
           <IconButton edge="start" color="inherit">
             <Icon />
           </IconButton>
           <Typography variant="h6">{t`controlPanel`}</Typography>
         </Box>
-        <Box display="flex" flexGrow="1" flexBasis="auto"></Box>
-        <Box
-          display="flex"
-          flexGrow="1"
-          flexBasis="20%"
-          justifyContent="flex-end"
-        >
+        <Box display="flex" flexGrow="1" justifyContent="flex-end">
           <Help />
           <LanguageSelector />
           <Identity />


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/141302/107157622-61f5d600-6985-11eb-8fe7-95cd1d09e507.png)

After:
![image](https://user-images.githubusercontent.com/141302/107157640-72a64c00-6985-11eb-902e-3a572b1794c1.png)

The issue tracker button now does not wrap on a significantly narrower screen.

Resolves #120 