### PR TITLE
[#126] Added feature to display vocabulary dependencies within workspace

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1891,9 +1891,9 @@
       }
     },
     "@opendata-mvcr/assembly-line-shared": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@opendata-mvcr/assembly-line-shared/-/assembly-line-shared-0.1.1.tgz",
-      "integrity": "sha512-f9aidR1c5sisJp4owQtJeCp4fnQ6p8rvsHDrRGstgp1l7Pnc23w/2xfW7nmLWavTVFIYJByJFFotWqsuqdA0PA==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@opendata-mvcr/assembly-line-shared/-/assembly-line-shared-0.1.2.tgz",
+      "integrity": "sha512-OgpN3KUy7w26jv0L1YHKJX7wJDKND+w3UQTSzI/WG9dcVVVOxrwIS2vn8MVNJxpfCKEltR+mohzlYRGUqGMAhg==",
       "requires": {
         "yaml": "^1.10.2"
       },
@@ -15951,6 +15951,16 @@
         "core-util-is": "1.0.2",
         "extsprintf": "^1.2.0"
       }
+    },
+    "vis-data": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/vis-data/-/vis-data-7.1.2.tgz",
+      "integrity": "sha512-RPSegFxEcnp3HUEJSzhS2vBdbJ2PSsrYYuhRlpHp2frO/MfRtTYbIkkLZmPkA/Sg3pPfBlR235gcoKbtdm4mbw=="
+    },
+    "vis-network": {
+      "version": "9.0.4",
+      "resolved": "https://registry.npmjs.org/vis-network/-/vis-network-9.0.4.tgz",
+      "integrity": "sha512-F/pq8yBJUuB9lNKXHhtn4GP2h91FV0c2O2nvfU34RX4VCYOlqs+mINdz+J+QkWiYhiPdlVy15gzVEzkhJ9hpaw=="
     },
     "vm-browserify": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "@material-ui/core": "^4.11.2",
     "@material-ui/icons": "^4.11.2",
     "@material-ui/lab": "^4.0.0-alpha.57",
-    "@opendata-mvcr/assembly-line-shared": "^0.1.1",
+    "@opendata-mvcr/assembly-line-shared": "^0.1.2",
     "@testing-library/jest-dom": "^5.11.9",
     "@testing-library/react": "^11.2.3",
     "@testing-library/user-event": "^12.6.2",
@@ -39,7 +39,9 @@
     "router5-plugin-logger": "^8.0.1",
     "rxjs": "^6.6.3",
     "typescript": "^4.1.3",
-    "uuid": "^8.3.2"
+    "uuid": "^8.3.2",
+    "vis-data": "^7.1.2",
+    "vis-network": "^9.0.4"
   },
   "devDependencies": {
     "cross-env": "^7.0.3",

--- a/src/components/vocabularies/VocabulariesDependencies.tsx
+++ b/src/components/vocabularies/VocabulariesDependencies.tsx
@@ -23,6 +23,7 @@ const buildGraph = (dependencies: Record<Iri, Iri[]>): Data => {
     nodes.push({
       id: iri,
       label: getVocabularyShortLabel(iri) || iri,
+      color: "#FFFFFF",
     });
   });
 

--- a/src/components/vocabularies/VocabulariesDependencies.tsx
+++ b/src/components/vocabularies/VocabulariesDependencies.tsx
@@ -1,0 +1,103 @@
+import React, { useRef, useEffect, useMemo } from "react";
+import { Box, makeStyles } from "@material-ui/core";
+import { Network, Data, Node, Edge } from "vis-network";
+import { flatten } from "lodash";
+
+import { getVocabularyShortLabel } from "@opendata-mvcr/assembly-line-shared";
+
+import { Iri } from "@types";
+
+import { useObservableSuspense } from "observable-hooks";
+import { workspaceVocabularyDependenciesResource } from "data/vocabularies";
+
+const buildGraph = (dependencies: Record<Iri, Iri[]>): Data => {
+  const nodes: Node[] = [];
+  const edges: Edge[] = [];
+
+  const mainVocabularies = Object.keys(dependencies);
+  const dependencyVocabularies = flatten(
+    mainVocabularies.map((key) => dependencies[key])
+  ).filter((dep) => !mainVocabularies.includes(dep));
+
+  mainVocabularies.forEach((iri) => {
+    nodes.push({
+      id: iri,
+      label: getVocabularyShortLabel(iri) || iri,
+    });
+  });
+
+  dependencyVocabularies.forEach((iri) => {
+    nodes.push({
+      id: iri,
+      label: getVocabularyShortLabel(iri) || iri,
+      color: "#FFD500",
+    });
+  });
+
+  mainVocabularies.map((key) =>
+    dependencies[key].forEach((dep) => {
+      edges.push({ from: key, to: dep });
+    })
+  );
+
+  return {
+    nodes,
+    edges,
+  };
+};
+
+const useStyles = makeStyles({
+  root: {
+    background: "#263238 linear-gradient(5deg, #057fa5 0%, #263238 100%)",
+  },
+  canvas: {
+    width: "100%",
+    height: 500,
+  },
+});
+
+const graphOptions = {
+  nodes: {
+    shape: "box",
+  },
+  edges: {
+    smooth: false,
+    color: "#000000",
+    width: 0.5,
+    arrows: {
+      to: {
+        enabled: true,
+        scaleFactor: 0.5,
+      },
+    },
+  },
+  layout: {
+    hierarchical: {
+      enabled: false,
+      nodeSpacing: 200,
+    },
+  },
+};
+
+const VocabulariesDependencies: React.FC = () => {
+  const classes = useStyles();
+  const canvas = useRef<HTMLDivElement>(null);
+
+  const dependencies = useObservableSuspense(
+    workspaceVocabularyDependenciesResource
+  );
+
+  const data = useMemo(() => buildGraph(dependencies), [dependencies]);
+
+  useEffect(() => {
+    new Network(canvas.current!, data, graphOptions);
+  }, [data]);
+
+  return (
+    <Box paddingBottom={2}>
+      <div className={classes.canvas} ref={canvas}></div>
+    </Box>
+  );
+};
+
+export default VocabulariesDependencies;

--- a/src/components/vocabularies/WorkspaceVocabularies.tsx
+++ b/src/components/vocabularies/WorkspaceVocabularies.tsx
@@ -4,6 +4,7 @@ import { Typography, Box } from "@material-ui/core";
 import t, { Namespace } from "components/i18n";
 import VocabulariesTable from "./VocabulariesTable";
 import AddVocabulary from "./AddVocabulary";
+import VocabulariesDependencies from "./VocabulariesDependencies";
 
 const WorkspaceVocabularies: React.FC = () => (
   <Namespace.Provider value="vocabularies">
@@ -14,6 +15,12 @@ const WorkspaceVocabularies: React.FC = () => (
       <AddVocabulary />
     </Box>
     <VocabulariesTable />
+    <Box paddingTop={2}>
+      <Typography variant="h5" paragraph>
+        {t`vocabulariesDependencies`}
+      </Typography>
+    </Box>
+    <VocabulariesDependencies />
   </Namespace.Provider>
 );
 

--- a/src/data/api.ts
+++ b/src/data/api.ts
@@ -44,3 +44,12 @@ export const getAddVocabularyUrl = (
  */
 export const getVocabularyUrl = (workspaceId: Id, vocabularyId: Id) =>
   `${getWorkspaceVocabulariesUrl(workspaceId)}/${vocabularyId}`;
+
+/**
+ * Endpoint to fetch a list of vocabulary dependencies for a particular vocabulary
+ */
+export const getWorkspaceVocabularyDependenciesUrl = (
+  workspaceId: Id,
+  vocabularyIri: Iri
+) =>
+  `${getWorkspaceUrl(workspaceId)}/dependencies?vocabularyIri=${vocabularyIri}`;

--- a/src/data/vocabularies.ts
+++ b/src/data/vocabularies.ts
@@ -1,4 +1,4 @@
-import { BehaviorSubject, Observable, Subject } from "rxjs";
+import { BehaviorSubject, forkJoin, Observable, Subject } from "rxjs";
 import {
   filter,
   map,
@@ -18,6 +18,7 @@ import {
   BaseVocabularyData,
   DeleteVocabularyPayload,
   Id,
+  Iri,
   UpdateVocabularyPayload,
   Vocabulary,
   VocabularyData,
@@ -32,6 +33,7 @@ import {
   getVocabulariesUrl,
   getVocabularyUrl,
   getWorkspaceVocabulariesUrl,
+  getWorkspaceVocabularyDependenciesUrl,
 } from "./api";
 
 export const convertVocabularyDataToVocabulary = (
@@ -97,6 +99,38 @@ export const fetchWorkspaceVocabularies = (workspaceId: Id) => {
     take(1)
   );
 };
+
+const workspaceVocabularyDependenciesResource$$ = fetchWorkspaceVocabularies$$.pipe(
+  throttleDistinct(100),
+  switchMap((workspaceId) =>
+    getJSON<VocabularyData[]>(getWorkspaceVocabulariesUrl(workspaceId)).pipe(
+      map((data) => data.map(convertVocabularyDataToVocabulary)),
+      switchMap(
+        (vocabularies) =>
+          forkJoin(
+            vocabularies.reduce((acc, vocabulary) => {
+              acc[vocabulary.vocabulary] = getJSON(
+                getWorkspaceVocabularyDependenciesUrl(
+                  workspaceId,
+                  vocabulary.vocabulary
+                )
+              );
+              return acc;
+            }, {} as Record<Iri, Observable<Iri[]>>)
+          ) as Observable<Record<Iri, Iri[]>>
+      )
+    )
+  ),
+  startWith(null),
+  share()
+);
+
+export const workspaceVocabularyDependenciesResource = new ObservableResource<
+  Record<Iri, Iri[]>
+>(
+  workspaceVocabularyDependenciesResource$$ as Observable<Record<Iri, Iri[]>>, // remove the null in typings as that is never emitted
+  (value: Record<Iri, Iri[]> | null): value is Record<Iri, Iri[]> => !!value
+);
 
 export const addVocabulary = (payload: AddVocabularyPayload) =>
   post(

--- a/src/i18n/vocabularies.cs.json
+++ b/src/i18n/vocabularies.cs.json
@@ -28,5 +28,6 @@
   "update": "Aktualizovat",
   "updating": "Aktualizuji...",
   "updateVocabularySuccess": "Slovník aktualizován",
-  "updateVocabularyError": "Nepodařilo se aktualizovat slovník"
+  "updateVocabularyError": "Nepodařilo se aktualizovat slovník",
+  "vocabulariesDependencies": "Závislosti mezi slovníky"
 }

--- a/src/i18n/vocabularies.en.json
+++ b/src/i18n/vocabularies.en.json
@@ -28,5 +28,6 @@
   "update": "Update",
   "updating": "Updating...",
   "updateVocabularySuccess": "The vocabulary was updated",
-  "updateVocabularyError": "The vocabulary cannot be updated"
+  "updateVocabularyError": "The vocabulary cannot be updated",
+  "vocabulariesDependencies": "Vocabulary dependencies"
 }


### PR DESCRIPTION
I consider this the first draft of the vocabulary dependencies feature, we can adjust the visuals later when we have more use cases of how users edit vocabularies within workspaces.

For now the network graph is interactive, we may add e.g. navigation to a read-only version of particular vocabulary on click.

Preview:
![image](https://user-images.githubusercontent.com/141302/114306210-7bc5ad80-9adb-11eb-97c5-c0be15441249.png)

Resolves #126.