### PR TITLE
[#178] Fixed sorting feature and default sorting order in tables

### DIFF
--- a/src/components/DataTable.tsx
+++ b/src/components/DataTable.tsx
@@ -1,4 +1,4 @@
-import React, { Suspense } from "react";
+import React, { Suspense, useState } from "react";
 import { makeStyles } from "@material-ui/styles";
 import {
   DataGrid,
@@ -6,15 +6,16 @@ import {
   GridColDef,
   GridRowData,
   GridRowsProp,
+  GridSortModel,
 } from "@material-ui/data-grid";
 import { ObservableResource, useObservableSuspense } from "observable-hooks";
 
 export type DataColumn = GridColDef;
 
 type DataTableProps = Omit<DataGridProps, "rows"> & {
-  type?: "simple" | "complex";
   data: GridRowsProp;
   isLoading: boolean;
+  defaultSortModel?: GridSortModel;
 };
 
 const useStyles = makeStyles({
@@ -31,15 +32,22 @@ const useStyles = makeStyles({
       outline: "none !important",
     },
   },
+  columnHeader: {
+    "&:focus": {
+      outline: "none !important",
+    },
+  },
 });
 
 const DataTable = ({
   isLoading = false,
   columns,
   data,
+  defaultSortModel,
   ...rest
 }: DataTableProps) => {
   const classes = useStyles();
+  const [sortModel, setSortModel] = useState(defaultSortModel);
 
   return (
     <DataGrid
@@ -49,6 +57,9 @@ const DataTable = ({
       rows={data}
       autoHeight
       loading={isLoading}
+      sortModel={sortModel}
+      onSortModelChange={(model) => setSortModel(model)}
+      sortingOrder={["asc", "desc"]}
       disableColumnMenu
       disableColumnSelector
       disableSelectionOnClick

--- a/src/components/vocabularies/VocabulariesTable.tsx
+++ b/src/components/vocabularies/VocabulariesTable.tsx
@@ -58,11 +58,11 @@ const getColumns = (
       />
     ),
     width: 200,
-    disableReorder: true,
+    sortable: false,
   },
 ];
 
-const sortModel: GridSortModel = [
+const defaultSortModel: GridSortModel = [
   {
     field: "label",
     sort: "asc",
@@ -105,8 +105,7 @@ const VocabulariesTable: React.FC = () => {
           workspaceVocabulariesResource as unknown as DataTableObservableResource
         }
         columns={columns}
-        sortModel={sortModel}
-        type="simple"
+        defaultSortModel={defaultSortModel}
         hideFooter
         rowHeight={76}
       />

--- a/src/components/workspaces/WorkspacesTable.tsx
+++ b/src/components/workspaces/WorkspacesTable.tsx
@@ -1,5 +1,9 @@
 import React, { useCallback, useTransition } from "react";
-import { GridColDef, GridSortModel } from "@material-ui/data-grid";
+import {
+  GridColDef,
+  GridSortModel,
+  GridValueGetterParams,
+} from "@material-ui/data-grid";
 
 import Routes from "app/routes";
 
@@ -25,6 +29,8 @@ const columns: GridColDef[] = [
     field: "owner",
     renderHeader: () => t`owner`,
     renderCell: (params) => <UserChip {...params.row.author} />,
+    valueGetter: (cellParams: GridValueGetterParams) =>
+      cellParams.row.author.initials,
     width: 150,
   },
   {
@@ -32,6 +38,8 @@ const columns: GridColDef[] = [
     renderHeader: () => t`lastEditor`,
     renderCell: (params) =>
       params.row.lastEditor && <UserChip {...params.row.lastEditor} />,
+    valueGetter: (cellParams: GridValueGetterParams) =>
+      cellParams.row.author.initials,
     width: 150,
   },
   {
@@ -39,6 +47,8 @@ const columns: GridColDef[] = [
     renderHeader: () => t`lastModified`,
     renderCell: (params) =>
       params.row.lastModified && formatDate(params.row.lastModified),
+    valueGetter: (cellParams: GridValueGetterParams) =>
+      cellParams.row.lastModified,
     width: 200,
   },
   {
@@ -46,10 +56,11 @@ const columns: GridColDef[] = [
     renderHeader: () => t`actions`,
     renderCell: (params) => <Tools workspaceUri={params.row.uri} />,
     width: 350,
+    sortable: false,
   },
 ];
 
-const sortModel: GridSortModel = [
+const defaultSortModel: GridSortModel = [
   {
     field: "label",
     sort: "asc",
@@ -74,7 +85,7 @@ const WorkspacesTable: React.FC = () => {
   return (
     <DataTableSuspense
       columns={columns}
-      sortModel={sortModel}
+      defaultSortModel={defaultSortModel}
       resource={workspacesResource as unknown as DataTableObservableResource}
       onRowClick={onRowClick}
       disableSelectionOnClick


### PR DESCRIPTION
Fixes #178.

Workspaces table and vocabularies table within workspace detail now have default sort on (by workspace name / vocabulary name). In addition it is possible to sort the data by clicking on headers of other columns.