### PR TITLE
[#181] Disable edit buttons if there are no vocabularies in workspace

### DIFF
--- a/src/@types/common.ts
+++ b/src/@types/common.ts
@@ -17,3 +17,8 @@ export type Message = {
 };
 
 export type Route = typeof Routes[keyof typeof Routes];
+
+export type Tool = {
+  key: string;
+  getUrl: (workspaceIri: Iri) => string;
+};

--- a/src/@types/workspaces.ts
+++ b/src/@types/workspaces.ts
@@ -87,9 +87,3 @@ export type Workspace = Omit<
   lastModified?: Date;
   vocabularies: Vocabulary[];
 };
-
-export type Tool = {
-  url: string;
-  label: string;
-  key: string;
-};

--- a/src/app/tools.ts
+++ b/src/app/tools.ts
@@ -1,10 +1,5 @@
 import { COMPONENTS } from "app/variables";
-import { Iri } from "@types";
-
-type Tool = {
-  key: string;
-  getUrl: (workspaceIri: Iri) => string;
-};
+import { Tool } from "@types";
 
 const tools: Tool[] = [
   {

--- a/src/components/workspaces/Tools.tsx
+++ b/src/components/workspaces/Tools.tsx
@@ -2,25 +2,45 @@ import React from "react";
 import { Button, Box } from "@material-ui/core";
 
 import tools from "app/tools";
+import { Tool, Workspace } from "@types";
 
 import t from "components/i18n";
 
-type ToolProps = { workspaceUri: string };
+type ToolButtonProps = {
+  tool: Tool;
+  workspace: Workspace;
+};
 
-const Tools: React.FC<ToolProps> = ({ workspaceUri }) => {
+const ToolButton: React.FC<ToolButtonProps> = ({ tool, workspace }) => {
+  if (workspace.vocabularies.length > 0) {
+    return (
+      <Button
+        color="primary"
+        variant="contained"
+        href={tool.getUrl(workspace.id)}
+        target="_blank"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {t(tool.key)}
+      </Button>
+    );
+  } else {
+    return (
+      <Button color="primary" variant="contained" disabled={true}>
+        {t(tool.key)}
+      </Button>
+    );
+  }
+};
+
+type ToolsProps = { workspace: Workspace };
+
+const Tools: React.FC<ToolsProps> = ({ workspace }) => {
   return (
     <>
       {tools.map((tool) => (
         <React.Fragment key={tool.key}>
-          <Button
-            color="primary"
-            variant="contained"
-            href={tool.getUrl(workspaceUri)}
-            target="_blank"
-            onClick={(e) => e.stopPropagation()}
-          >
-            {t(tool.key)}
-          </Button>
+          <ToolButton tool={tool} workspace={workspace} />
           <Box m={1} />
         </React.Fragment>
       ))}

--- a/src/components/workspaces/WorkspaceActions.tsx
+++ b/src/components/workspaces/WorkspaceActions.tsx
@@ -41,7 +41,7 @@ const WorkspaceActions: React.FC = () => {
   return (
     <>
       <Box my={2} display="flex" flexDirection="row">
-        <Tools workspaceUri={workspace?.uri} />
+        <Tools workspace={workspace} />
         <Button color="primary" variant="contained" onClick={publish.open}>
           {t`publish`}
         </Button>

--- a/src/components/workspaces/WorkspacesTable.tsx
+++ b/src/components/workspaces/WorkspacesTable.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useTransition } from "react";
 import { GridColDef, GridSortModel } from "@material-ui/data-grid";
 
 import Routes from "app/routes";
+import { Workspace } from "@types";
 
 import t from "components/i18n";
 import {
@@ -44,7 +45,7 @@ const columns: GridColDef[] = [
   {
     field: "actions",
     renderHeader: () => t`actions`,
-    renderCell: (params) => <Tools workspaceUri={params.row.uri} />,
+    renderCell: (params) => <Tools workspace={params.row as Workspace} />,
     width: 350,
   },
 ];


### PR DESCRIPTION
Resolves #181.

If there are no vocabularies in workspace, the buttons leading to TermIt and ontoGrapher will be disabled. Should work on both workspaces screen and workspace detail screen.