### PR TITLE
[#220] Prevent creating a vocabulary with duplicate IRI

### DIFF
--- a/src/components/vocabularies/CreateVocabularyForm.tsx
+++ b/src/components/vocabularies/CreateVocabularyForm.tsx
@@ -19,8 +19,13 @@ import Form from "components/form/Form";
 import Hidden from "components/form/Hidden";
 import FormTextField from "components/form/TextField";
 import Checkbox from "components/form/Checkbox";
-import { addVocabulary, fetchWorkspaceVocabularies } from "data/vocabularies";
+import {
+  addVocabulary,
+  fetchWorkspaceVocabularies,
+  vocabulariesResource,
+} from "data/vocabularies";
 import { execute } from "utils/epic";
+import { useObservableSuspense } from "observable-hooks";
 
 type CreateVocabularyFormProps = {
   workspace: Workspace;
@@ -31,6 +36,12 @@ const CreateVocabularyForm: React.FC<CreateVocabularyFormProps> = ({
   workspace,
   onClose,
 }) => {
+  const existingVocabularies = useObservableSuspense(vocabulariesResource);
+
+  const restrictedVocabularyIris = existingVocabularies.map(
+    (v) => v.vocabulary
+  );
+
   const form = useForm();
 
   const onSubmit = useCallback(
@@ -130,6 +141,9 @@ const CreateVocabularyForm: React.FC<CreateVocabularyFormProps> = ({
               value: new RegExp(vocabularyType?.regex!),
               message: vocabularyType?.regex!,
             },
+            validate: (value) =>
+              !restrictedVocabularyIris.includes(value) ||
+              "vocabularyIriExists",
           }}
         />
         <SubmitButton

--- a/src/i18n/vocabularies.cs.json
+++ b/src/i18n/vocabularies.cs.json
@@ -10,6 +10,7 @@
   "addVocabularySuccess": "Slovník přídán do pracovního prostoru",
   "addVocabularyError": "Nepodařilo se přidat slovník do pracovního prostoru",
   "addVocabularyErrorEditableDuplicate": "Vybraný slovník již existuje v režimu zápisu v jiném pracovním prostoru",
+  "vocabularyIriExists": "Slovník s touto IRI již existuje",
   "importVocabulary": "Import slovníku",
   "addAnyway": "Přesto přidat",
   "vocabularyEditedInAnotherWorkspace": "Slovník je upravován v pracovním prostoru:",

--- a/src/i18n/vocabularies.en.json
+++ b/src/i18n/vocabularies.en.json
@@ -10,6 +10,7 @@
   "addVocabularySuccess": "Vocabulary was added to the workspace",
   "addVocabularyError": "Vocabulary cannot be added to the workspace",
   "addVocabularyErrorEditableDuplicate": "Selected vocabulary already exists in edit mode in another workspace",
+  "vocabularyIriExists": "Vocabulary with this IRI already exists",
   "importVocabulary": "Import vocabulary",
   "addAnyway": "Add anyway",
   "vocabularyEditedInAnotherWorkspace": "Vocabulary is being edited in workspace:",


### PR DESCRIPTION
Resolves #220.

From now on it should not be possible to create a vocabulary within a workspace with IRI that already exists in SGoV.