### PR TITLE
[#218] Added support for linking to tools using vocabulary IRIs

### DIFF
--- a/src/@types/common.ts
+++ b/src/@types/common.ts
@@ -20,5 +20,5 @@ export type Route = typeof Routes[keyof typeof Routes];
 
 export type Tool = {
   key: string;
-  getUrl: (workspaceIri: Iri) => string;
+  getUrl: (workspaceIri: Iri, vocabularyIris: Iri[]) => string;
 };

--- a/src/app/tools.ts
+++ b/src/app/tools.ts
@@ -1,25 +1,31 @@
 import { COMPONENTS } from "app/variables";
-import { Tool } from "@types";
+import { Tool, Iri } from "@types";
+
+const buildQueryString = (vocabularyIris: Iri[]) => {
+  return vocabularyIris.map((vocab) => `vocabulary=${vocab}`).join("&");
+};
 
 const tools: Tool[] = [
   {
     key: "editTerms",
-    getUrl: (workspaceIri) => {
+    getUrl: (workspaceIri, workspacesIris) => {
+      const queryString = buildQueryString(workspacesIris);
       const path = COMPONENTS["al-termit"].meta["workspace-path"].replace(
         "%WORKSPACE_IRI%",
         workspaceIri
       );
-      return `${COMPONENTS["al-termit"].url}${path}`;
+      return `${COMPONENTS["al-termit"].url}${path}&${queryString}`;
     },
   },
   {
     key: "editRelations",
-    getUrl: (workspaceIri) => {
+    getUrl: (workspaceIri, workspacesIris) => {
+      const queryString = buildQueryString(workspacesIris);
       const path = COMPONENTS["al-ontographer"].meta["workspace-path"].replace(
         "%WORKSPACE_IRI%",
         workspaceIri
       );
-      return `${COMPONENTS["al-ontographer"].url}${path}`;
+      return `${COMPONENTS["al-ontographer"].url}${path}&${queryString}`;
     },
   },
 ];

--- a/src/components/workspaces/Tools.tsx
+++ b/src/components/workspaces/Tools.tsx
@@ -17,7 +17,10 @@ const ToolButton: React.FC<ToolButtonProps> = ({ tool, workspace }) => {
       <Button
         color="primary"
         variant="contained"
-        href={tool.getUrl(workspace.uri)}
+        href={tool.getUrl(
+          workspace.uri,
+          workspace.vocabularies.map((v) => v.vocabularyContext)
+        )}
         target="_blank"
         onClick={(e) => e.stopPropagation()}
       >


### PR DESCRIPTION
@bindeali I have added a list of vocabularies to query string when linking to OntoGrapher and TermIt. I figured that there is no reason why we couldn't have both the workspace IRI and vocabulary IRIs in the URL now, it shouldn't break anything and will be easier to debug hopefully.

Resolves #218.